### PR TITLE
feat(landing): infrawatcher.unmong.com 시작페이지 (GatewayLanding) 신규

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import AppLayout from './components/layout/AppLayout';
 import DashboardPage from './pages/DashboardPage';
 import ContainerDetailPage from './pages/ContainerDetailPage';
 import GroupDetailPage from './pages/GroupDetailPage';
+import GatewayLanding from './pages/gateway-landing/GatewayLanding';
 import { useWebSocket } from './hooks/useWebSocket';
 
 const App: React.FC = () => {
@@ -19,13 +20,33 @@ const App: React.FC = () => {
         },
       }}
     >
-      <AppLayout connected={connected}>
-        <Routes>
-          <Route path="/" element={<DashboardPage snapshot={snapshot} />} />
-          <Route path="/container/:containerName" element={<ContainerDetailPage snapshot={snapshot} />} />
-          <Route path="/group/:groupName" element={<GroupDetailPage snapshot={snapshot} />} />
-        </Routes>
-      </AppLayout>
+      <Routes>
+        <Route path="/" element={<GatewayLanding />} />
+        <Route
+          path="/dashboard"
+          element={
+            <AppLayout connected={connected}>
+              <DashboardPage snapshot={snapshot} />
+            </AppLayout>
+          }
+        />
+        <Route
+          path="/container/:containerName"
+          element={
+            <AppLayout connected={connected}>
+              <ContainerDetailPage snapshot={snapshot} />
+            </AppLayout>
+          }
+        />
+        <Route
+          path="/group/:groupName"
+          element={
+            <AppLayout connected={connected}>
+              <GroupDetailPage snapshot={snapshot} />
+            </AppLayout>
+          }
+        />
+      </Routes>
     </ConfigProvider>
   );
 };

--- a/frontend/src/pages/gateway-landing/GatewayLanding.css
+++ b/frontend/src/pages/gateway-landing/GatewayLanding.css
@@ -1,0 +1,554 @@
+.gateway-landing-root {
+    --bg-color: #0f172a;
+    --card-bg: rgba(30, 41, 59, 0.85);
+    --card-bg-hover: rgba(30, 41, 59, 0.95);
+    --text-color: #e2e8f0;
+    --text-muted: #94a3b8;
+    --text-dim: #64748b;
+    --accent-color: #3b82f6;
+    --border-color: rgba(148, 163, 184, 0.15);
+    --service-color: #06b6d4;
+    --glow-r: 6;
+    --glow-g: 182;
+    --glow-b: 212;
+
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--bg-color);
+    color: var(--text-color);
+    min-height: 100vh;
+    overflow-x: hidden;
+    position: relative;
+}
+
+.gateway-landing-root::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background-image:
+        linear-gradient(rgba(148, 163, 184, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(148, 163, 184, 0.03) 1px, transparent 1px);
+    background-size: 40px 40px;
+    pointer-events: none;
+}
+
+.gateway-landing-root::after {
+    content: '';
+    position: fixed;
+    inset: -50%;
+    width: 200%;
+    height: 200%;
+    background:
+        radial-gradient(ellipse at 30% 10%, rgba(6, 182, 212, 0.08) 0%, transparent 50%),
+        radial-gradient(ellipse at 70% 90%, rgba(139, 92, 246, 0.05) 0%, transparent 50%);
+    pointer-events: none;
+}
+
+.gateway-landing-root .sl-container {
+    position: relative;
+    z-index: 1;
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2rem 2rem 3rem;
+}
+
+/* ── Hero ── */
+.gateway-landing-root .sl-hero {
+    text-align: center;
+    padding: 2.5rem 1.5rem;
+    margin-bottom: 2rem;
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    background: var(--card-bg);
+    position: relative;
+    overflow: hidden;
+    animation: glFadeInUp 0.7s ease-out 0.1s backwards;
+}
+
+.gateway-landing-root .sl-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, var(--service-color), transparent);
+}
+
+.gateway-landing-root .sl-hero h1 {
+    font-size: 2.2rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    margin: 0 0 0.3rem;
+    color: #f1f5f9;
+}
+
+.gateway-landing-root .sl-hero .tagline {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    font-weight: 300;
+    margin: 0 0 0.4rem;
+}
+
+.gateway-landing-root .sl-hero .desc {
+    font-size: 0.85rem;
+    color: var(--text-dim);
+    max-width: 620px;
+    margin: 0 auto;
+    line-height: 1.65;
+}
+
+/* ── Section titles ── */
+.gateway-landing-root .sl-section {
+    margin-bottom: 1.75rem;
+}
+
+.gateway-landing-root .sl-section-title {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--service-color);
+    margin-bottom: 0.85rem;
+    padding-left: 0.6rem;
+    border-left: 2px solid var(--service-color);
+}
+
+/* ── Features Grid ── */
+.gateway-landing-root .sl-features {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.85rem;
+    animation: glFadeInUp 0.7s ease-out 0.2s backwards;
+}
+
+.gateway-landing-root .sl-feature {
+    position: relative;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1rem;
+    transition: all 0.25s;
+    text-decoration: none;
+    display: block;
+    cursor: pointer;
+    color: inherit;
+}
+
+.gateway-landing-root .sl-feature:hover {
+    background: var(--card-bg-hover);
+    border-color: rgba(148, 163, 184, 0.25);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px -6px rgba(0, 0, 0, 0.3);
+}
+
+.gateway-landing-root .sl-feature[data-locked="true"] {
+    opacity: 0.78;
+}
+
+.gateway-landing-root .sl-feature[data-locked="true"]:hover {
+    opacity: 1;
+}
+
+.gateway-landing-root .sl-feature-lock {
+    position: absolute;
+    top: 0.6rem;
+    right: 0.7rem;
+    font-size: 0.85rem;
+    color: var(--text-dim);
+    line-height: 1;
+}
+
+.gateway-landing-root .sl-feature[data-locked="true"]:hover .sl-feature-lock {
+    color: var(--text-muted);
+}
+
+.gateway-landing-root .sl-feature-icon {
+    font-size: 1.4rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.gateway-landing-root .sl-feature-name {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin-bottom: 0.3rem;
+}
+
+.gateway-landing-root .sl-feature-desc {
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    line-height: 1.45;
+}
+
+.gateway-landing-root .sl-feature-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    margin-top: 0.6rem;
+    font-size: 0.62rem;
+    font-weight: 600;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    text-transform: none;
+    letter-spacing: 0.02em;
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--text-muted);
+}
+
+.gateway-landing-root .sl-feature-tag--public {
+    background: rgba(16, 185, 129, 0.12);
+    color: #10b981;
+}
+
+.gateway-landing-root .sl-feature-tag--member-locked {
+    background: rgba(245, 158, 11, 0.14);
+    color: #fbbf24;
+}
+
+.gateway-landing-root .sl-feature-tag--admin-locked {
+    background: rgba(239, 68, 68, 0.14);
+    color: #f87171;
+}
+
+.gateway-landing-root .sl-feature-tag--granted {
+    background: rgba(16, 185, 129, 0.08);
+    color: rgba(52, 211, 153, 0.85);
+}
+
+/* ── Architecture Diagram ── */
+.gateway-landing-root .sl-arch {
+    animation: glFadeInUp 0.7s ease-out 0.3s backwards;
+}
+
+.gateway-landing-root .sl-arch-diagram {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    flex-wrap: wrap;
+}
+
+.gateway-landing-root .sl-arch-node {
+    text-align: center;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: rgba(15, 23, 42, 0.6);
+    min-width: 100px;
+}
+
+.gateway-landing-root .sl-arch-node-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin-bottom: 0.2rem;
+}
+
+.gateway-landing-root .sl-arch-node-tech {
+    font-size: 0.6rem;
+    color: var(--text-dim);
+}
+
+.gateway-landing-root .sl-arch-node-tech-sub {
+    opacity: 0.7;
+    font-size: 0.85em;
+}
+
+.gateway-landing-root .sl-arch-node.highlight {
+    border-color: var(--service-color);
+    box-shadow: 0 0 12px rgba(6, 182, 212, 0.15);
+}
+
+.gateway-landing-root .sl-arch-arrow {
+    padding: 0 0.6rem;
+    color: var(--text-dim);
+    font-size: 1rem;
+}
+
+/* ── Flow Diagram ── */
+.gateway-landing-root .sl-flow {
+    animation: glFadeInUp 0.7s ease-out 0.35s backwards;
+}
+
+.gateway-landing-root .sl-flow-steps {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0;
+    overflow-x: auto;
+}
+
+.gateway-landing-root .sl-flow-step {
+    text-align: center;
+    flex-shrink: 0;
+    padding: 0.6rem 0.8rem;
+}
+
+.gateway-landing-root .sl-flow-step-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: rgba(6, 182, 212, 0.15);
+    color: var(--service-color);
+    font-size: 0.65rem;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+}
+
+.gateway-landing-root .sl-flow-step-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #f1f5f9;
+    margin-bottom: 0.15rem;
+    white-space: nowrap;
+}
+
+.gateway-landing-root .sl-flow-step-desc {
+    font-size: 0.6rem;
+    color: var(--text-dim);
+    white-space: nowrap;
+}
+
+.gateway-landing-root .sl-flow-arrow {
+    flex-shrink: 0;
+    color: var(--text-dim);
+    font-size: 0.85rem;
+    padding: 0 0.3rem;
+    opacity: 0.5;
+}
+
+/* ── Tech Stack ── */
+.gateway-landing-root .sl-tech {
+    animation: glFadeInUp 0.7s ease-out 0.4s backwards;
+}
+
+.gateway-landing-root .sl-tech-list {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.gateway-landing-root .sl-tech-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.4rem 0.75rem;
+    border-radius: 8px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    transition: border-color 0.2s;
+}
+
+.gateway-landing-root .sl-tech-badge:hover {
+    border-color: rgba(148, 163, 184, 0.3);
+}
+
+.gateway-landing-root .sl-tech-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+}
+
+/* ── Connected Services ── */
+.gateway-landing-root .sl-connected {
+    animation: glFadeInUp 0.7s ease-out 0.45s backwards;
+}
+
+.gateway-landing-root .sl-connected-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 0.7rem;
+}
+
+.gateway-landing-root .sl-connected-card {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    text-decoration: none;
+    transition: all 0.2s;
+    color: inherit;
+}
+
+.gateway-landing-root .sl-connected-card:hover {
+    background: var(--card-bg-hover);
+    border-color: rgba(148, 163, 184, 0.25);
+    transform: translateY(-1px);
+}
+
+.gateway-landing-root .sl-connected-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.gateway-landing-root .sl-connected-info {
+    flex: 1;
+}
+
+.gateway-landing-root .sl-connected-name {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: #f1f5f9;
+}
+
+.gateway-landing-root .sl-connected-role {
+    font-size: 0.62rem;
+    color: var(--text-dim);
+}
+
+.gateway-landing-root .sl-connected-arrow {
+    color: var(--text-dim);
+    font-size: 0.8rem;
+    transition: color 0.2s;
+}
+
+.gateway-landing-root .sl-connected-card:hover .sl-connected-arrow {
+    color: var(--service-color);
+}
+
+/* ── Toast ── */
+.gateway-landing-root .sl-toast {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(15, 23, 42, 0.97);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.7rem 1rem 0.7rem 1.1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    font-size: 0.82rem;
+    color: var(--text-color);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+    animation: glToastIn 0.25s ease-out;
+    z-index: 1000;
+    max-width: calc(100vw - 2rem);
+}
+
+.gateway-landing-root .sl-toast-icon {
+    font-size: 1rem;
+    line-height: 1;
+}
+
+.gateway-landing-root .sl-toast-msg {
+    flex: 1;
+}
+
+.gateway-landing-root .sl-toast-action {
+    color: var(--service-color);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.78rem;
+    padding: 0.25rem 0.6rem;
+    border-radius: 6px;
+    border: 1px solid rgba(6, 182, 212, 0.3);
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+
+.gateway-landing-root .sl-toast-action:hover {
+    background: rgba(6, 182, 212, 0.12);
+    border-color: var(--service-color);
+}
+
+.gateway-landing-root .sl-toast-close {
+    background: transparent;
+    border: none;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 0 0.15rem;
+    transition: color 0.15s;
+}
+
+.gateway-landing-root .sl-toast-close:hover {
+    color: var(--text-color);
+}
+
+/* ── Animations ── */
+@keyframes glFadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(16px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes glToastIn {
+    from {
+        opacity: 0;
+        transform: translate(-50%, 12px);
+    }
+    to {
+        opacity: 1;
+        transform: translate(-50%, 0);
+    }
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+    .gateway-landing-root .sl-container {
+        padding: 1.5rem 1rem 2rem;
+    }
+
+    .gateway-landing-root .sl-hero h1 {
+        font-size: 1.6rem;
+    }
+
+    .gateway-landing-root .sl-hero {
+        padding: 1.75rem 1rem;
+    }
+
+    .gateway-landing-root .sl-features {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .gateway-landing-root .sl-arch-diagram {
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .gateway-landing-root .sl-arch-arrow {
+        transform: rotate(90deg);
+        padding: 0.3rem 0;
+    }
+}
+
+@media (max-width: 480px) {
+    .gateway-landing-root .sl-features {
+        grid-template-columns: 1fr;
+    }
+
+    .gateway-landing-root .sl-connected-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .gateway-landing-root .sl-flow-steps {
+        padding: 1rem;
+    }
+}

--- a/frontend/src/pages/gateway-landing/GatewayLanding.tsx
+++ b/frontend/src/pages/gateway-landing/GatewayLanding.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import './GatewayLanding.css';
+
+interface Feature {
+  icon: string;
+  name: string;
+  desc: string;
+  to: string;
+  external?: boolean;
+}
+
+const FEATURES: Feature[] = [
+  {
+    icon: '📡',
+    name: '실시간 대시보드',
+    desc: '전체 컨테이너 상태·CPU/메모리 사용량을 WebSocket 실시간 스트림으로 모니터링',
+    to: '/dashboard',
+  },
+  {
+    icon: '🟢',
+    name: '헬스체크',
+    desc: '컨테이너별 헬스 상태 자동 점검과 이상 감지 — 그룹/개별 단위 추적',
+    to: '/dashboard',
+  },
+  {
+    icon: '📂',
+    name: '그룹 관리',
+    desc: '서비스 그룹별 컨테이너 묶음 보기 — 의존 관계와 영향 범위 시각화',
+    to: '/group',
+  },
+  {
+    icon: '🔌',
+    name: 'API Docs',
+    desc: 'Swagger UI 기반 OpenAPI 명세 — 컨테이너 상태 조회 REST API',
+    to: '/api/docs',
+    external: true,
+  },
+];
+
+interface Tech { name: string; dot: string; }
+const TECH_STACK: Tech[] = [
+  { name: 'React 18', dot: '#61dafb' },
+  { name: 'TypeScript', dot: '#3178c6' },
+  { name: 'Ant Design', dot: '#1677ff' },
+  { name: 'FastAPI', dot: '#009688' },
+  { name: 'WebSocket', dot: '#7c3aed' },
+  { name: 'Docker Engine API', dot: '#2496ed' },
+  { name: 'SQLite', dot: '#003b57' },
+];
+
+interface Connected { name: string; role: string; href: string; dot: string; }
+const CONNECTED_SERVICES: Connected[] = [
+  { name: 'AllergyInsight', role: '모니터링 대상', href: 'https://allergy.unmong.com', dot: '#f43f5e' },
+  { name: 'EduFit', role: '모니터링 대상', href: 'https://edufit.unmong.com', dot: '#22c55e' },
+  { name: 'NewsLetterPlatform', role: '모니터링 대상', href: 'https://newsletter.unmong.com', dot: '#ec4899' },
+  { name: 'StandUp', role: '모니터링 대상', href: 'https://standup.unmong.com', dot: '#14b8a6' },
+  { name: 'QA-Agent', role: '품질 자동 테스트', href: 'https://qadashboard.unmong.com', dot: '#8b5cf6' },
+  { name: 'LogAnalyzer', role: '로그 연계', href: 'https://loganalyzer.unmong.com', dot: '#f59e0b' },
+];
+
+interface FeatureCardProps { feature: Feature; }
+
+const FeatureCard: React.FC<FeatureCardProps> = ({ feature }) => {
+  const inner = (
+    <>
+      <span className="sl-feature-icon" aria-hidden="true">{feature.icon}</span>
+      <div className="sl-feature-name">{feature.name}</div>
+      <div className="sl-feature-desc">{feature.desc}</div>
+      <span className="sl-feature-tag sl-feature-tag--public">🌐 공개</span>
+    </>
+  );
+
+  if (feature.external) {
+    return (
+      <a className="sl-feature" data-locked="false" href={feature.to} target="_blank" rel="noopener noreferrer">
+        {inner}
+      </a>
+    );
+  }
+  return (
+    <Link className="sl-feature" data-locked="false" to={feature.to}>
+      {inner}
+    </Link>
+  );
+};
+
+const GatewayLanding: React.FC = () => {
+  return (
+    <div className="gateway-landing-root">
+      <div className="sl-container">
+        <section className="sl-hero">
+          <h1>InfraWatcher</h1>
+          <p className="tagline">Docker Container Monitoring · Real-time Dashboard</p>
+          <p className="desc">
+            Docker 컨테이너의 실시간 상태를 WebSocket 으로 스트리밍하고, 이상 감지 시 알림을 제공하는 인프라 관제 시스템 — 전체 서비스 헬스 상태를 한 화면에서 확인
+          </p>
+        </section>
+
+        <section className="sl-section">
+          <div className="sl-section-title">Features</div>
+          <div className="sl-features">
+            {FEATURES.map((feature) => (
+              <FeatureCard key={feature.name} feature={feature} />
+            ))}
+          </div>
+        </section>
+
+        <section className="sl-section sl-arch">
+          <div className="sl-section-title">Architecture</div>
+          <div className="sl-arch-diagram">
+            <div className="sl-arch-node">
+              <div className="sl-arch-node-label">Docker Engine</div>
+              <div className="sl-arch-node-tech">Socket API<br /><span className="sl-arch-node-tech-sub">컨테이너 메트릭</span></div>
+            </div>
+            <div className="sl-arch-arrow">→</div>
+            <div className="sl-arch-node highlight">
+              <div className="sl-arch-node-label">Backend</div>
+              <div className="sl-arch-node-tech">FastAPI<br /><span className="sl-arch-node-tech-sub">+ WebSocket</span></div>
+            </div>
+            <div className="sl-arch-arrow">→</div>
+            <div className="sl-arch-node">
+              <div className="sl-arch-node-label">Storage</div>
+              <div className="sl-arch-node-tech">SQLite<br /><span className="sl-arch-node-tech-sub">상태 이력</span></div>
+            </div>
+            <div className="sl-arch-arrow">←</div>
+            <div className="sl-arch-node">
+              <div className="sl-arch-node-label">Frontend</div>
+              <div className="sl-arch-node-tech">React + AntD<br /><span className="sl-arch-node-tech-sub">실시간 시각화</span></div>
+            </div>
+          </div>
+        </section>
+
+        <section className="sl-section sl-flow">
+          <div className="sl-section-title">Service Flow</div>
+          <div className="sl-flow-steps">
+            <div className="sl-flow-step">
+              <div className="sl-flow-step-num">1</div>
+              <div className="sl-flow-step-label">Docker 연결</div>
+              <div className="sl-flow-step-desc">Socket API 접근</div>
+            </div>
+            <div className="sl-flow-arrow">→</div>
+            <div className="sl-flow-step">
+              <div className="sl-flow-step-num">2</div>
+              <div className="sl-flow-step-label">상태 수집</div>
+              <div className="sl-flow-step-desc">컨테이너 메트릭</div>
+            </div>
+            <div className="sl-flow-arrow">→</div>
+            <div className="sl-flow-step">
+              <div className="sl-flow-step-num">3</div>
+              <div className="sl-flow-step-label">이상 감지</div>
+              <div className="sl-flow-step-desc">헬스체크 분석</div>
+            </div>
+            <div className="sl-flow-arrow">→</div>
+            <div className="sl-flow-step">
+              <div className="sl-flow-step-num">4</div>
+              <div className="sl-flow-step-label">대시보드</div>
+              <div className="sl-flow-step-desc">실시간 스트림</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="sl-section sl-tech">
+          <div className="sl-section-title">Tech Stack</div>
+          <div className="sl-tech-list">
+            {TECH_STACK.map((tech) => (
+              <span className="sl-tech-badge" key={tech.name}>
+                <span className="sl-tech-dot" style={{ background: tech.dot }} />
+                {tech.name}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        <section className="sl-section sl-connected">
+          <div className="sl-section-title">Connected Services</div>
+          <div className="sl-connected-grid">
+            {CONNECTED_SERVICES.map((svc) => (
+              <a
+                key={svc.name}
+                href={svc.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="sl-connected-card"
+              >
+                <span className="sl-connected-dot" style={{ background: svc.dot }} />
+                <div className="sl-connected-info">
+                  <div className="sl-connected-name">{svc.name}</div>
+                  <div className="sl-connected-role">{svc.role}</div>
+                </div>
+                <span className="sl-connected-arrow">→</span>
+              </a>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default GatewayLanding;

--- a/frontend/src/pages/gateway-landing/GatewayLanding.tsx
+++ b/frontend/src/pages/gateway-landing/GatewayLanding.tsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import './GatewayLanding.css';
+
+type Level = 'public' | 'member' | 'admin';
+type AccessState = 'granted' | 'member-locked' | 'admin-locked';
 
 interface Feature {
   icon: string;
   name: string;
   desc: string;
+  level: Level;
   to: string;
   external?: boolean;
 }
@@ -15,24 +19,28 @@ const FEATURES: Feature[] = [
     icon: '📡',
     name: '실시간 대시보드',
     desc: '전체 컨테이너 상태·CPU/메모리 사용량을 WebSocket 실시간 스트림으로 모니터링',
+    level: 'public',
     to: '/dashboard',
   },
   {
     icon: '🟢',
     name: '헬스체크',
     desc: '컨테이너별 헬스 상태 자동 점검과 이상 감지 — 그룹/개별 단위 추적',
+    level: 'public',
     to: '/dashboard',
   },
   {
     icon: '📂',
     name: '그룹 관리',
     desc: '서비스 그룹별 컨테이너 묶음 보기 — 의존 관계와 영향 범위 시각화',
-    to: '/group',
+    level: 'public',
+    to: '/dashboard',
   },
   {
     icon: '🔌',
     name: 'API Docs',
     desc: 'Swagger UI 기반 OpenAPI 명세 — 컨테이너 상태 조회 REST API',
+    level: 'public',
     to: '/api/docs',
     external: true,
   },
@@ -40,52 +48,144 @@ const FEATURES: Feature[] = [
 
 interface Tech { name: string; dot: string; }
 const TECH_STACK: Tech[] = [
-  { name: 'React 18', dot: '#61dafb' },
+  { name: 'React 18 + Vite', dot: '#61dafb' },
   { name: 'TypeScript', dot: '#3178c6' },
-  { name: 'Ant Design', dot: '#1677ff' },
+  { name: 'Ant Design 5', dot: '#1677ff' },
   { name: 'FastAPI', dot: '#009688' },
   { name: 'WebSocket', dot: '#7c3aed' },
   { name: 'Docker Engine API', dot: '#2496ed' },
-  { name: 'SQLite', dot: '#003b57' },
+  { name: 'APScheduler', dot: '#10b981' },
+  { name: 'psutil', dot: '#eab308' },
+  { name: 'SQLite (WAL)', dot: '#003b57' },
+  { name: 'Recharts', dot: '#ff6f61' },
+  { name: 'Nginx', dot: '#f97316' },
 ];
 
 interface Connected { name: string; role: string; href: string; dot: string; }
 const CONNECTED_SERVICES: Connected[] = [
-  { name: 'AllergyInsight', role: '모니터링 대상', href: 'https://allergy.unmong.com', dot: '#f43f5e' },
-  { name: 'EduFit', role: '모니터링 대상', href: 'https://edufit.unmong.com', dot: '#22c55e' },
-  { name: 'NewsLetterPlatform', role: '모니터링 대상', href: 'https://newsletter.unmong.com', dot: '#ec4899' },
-  { name: 'StandUp', role: '모니터링 대상', href: 'https://standup.unmong.com', dot: '#14b8a6' },
-  { name: 'QA-Agent', role: '품질 자동 테스트', href: 'https://qadashboard.unmong.com', dot: '#8b5cf6' },
-  { name: 'LogAnalyzer', role: '로그 연계', href: 'https://loganalyzer.unmong.com', dot: '#f59e0b' },
+  { name: 'AllergyInsight', role: '모니터링 대상', href: 'https://allergy.unmong.com/', dot: '#f43f5e' },
+  { name: 'NewsLetterPlatform', role: '모니터링 대상', href: 'https://newsletter.unmong.com/', dot: '#ec4899' },
+  { name: 'EduFit', role: '모니터링 대상', href: 'https://edufit.unmong.com/', dot: '#22c55e' },
+  { name: 'HopenVision', role: '모니터링 대상', href: 'https://hopenvision.unmong.com/', dot: '#3b82f6' },
+  { name: 'StandUp', role: '모니터링 대상', href: 'https://standup.unmong.com/', dot: '#14b8a6' },
+  { name: 'QA-Agent', role: '품질 자동 테스트', href: 'https://qadashboard.unmong.com/', dot: '#8b5cf6' },
+  { name: 'LogAnalyzer', role: '로그 연계', href: 'https://loganalyzer.unmong.com/', dot: '#f59e0b' },
 ];
 
-interface FeatureCardProps { feature: Feature; }
+interface AuthState { isAuthenticated: boolean; isAdmin: boolean; }
 
-const FeatureCard: React.FC<FeatureCardProps> = ({ feature }) => {
+function accessFor(level: Level, { isAuthenticated, isAdmin }: AuthState): AccessState {
+  if (level === 'public') return 'granted';
+  if (level === 'member') return isAuthenticated ? 'granted' : 'member-locked';
+  if (level === 'admin') return isAdmin ? 'granted' : 'admin-locked';
+  return 'granted';
+}
+
+interface TagInfo { label: string; variant: string; }
+function tagInfo(state: AccessState, level: Level): TagInfo {
+  if (state === 'granted' && level === 'public') return { label: '🌐 공개', variant: 'public' };
+  if (state === 'granted') return { label: '✓ 사용 가능', variant: 'granted' };
+  if (state === 'member-locked') return { label: '🔒 회원전용', variant: 'member-locked' };
+  if (state === 'admin-locked') return { label: '🔐 관리자 전용', variant: 'admin-locked' };
+  return { label: '', variant: '' };
+}
+
+interface ToastModel { icon: string; message: string; actionLabel: string; actionTo: string; }
+function lockedToastFor(state: AccessState): ToastModel | null {
+  if (state === 'member-locked') {
+    return { icon: '🔒', message: '회원전용 서비스입니다', actionLabel: '로그인', actionTo: '/login' };
+  }
+  if (state === 'admin-locked') {
+    return { icon: '🔐', message: '관리자 전용입니다', actionLabel: '관리자 로그인', actionTo: '/admin/login' };
+  }
+  return null;
+}
+
+interface FeatureCardProps {
+  feature: Feature;
+  accessState: AccessState;
+  onLocked: (state: AccessState) => void;
+}
+
+const FeatureCard: React.FC<FeatureCardProps> = ({ feature, accessState, onLocked }) => {
+  const locked = accessState !== 'granted';
+  const { label, variant } = tagInfo(accessState, feature.level);
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (locked) {
+      e.preventDefault();
+      onLocked(accessState);
+    }
+  };
+
   const inner = (
     <>
+      {locked && <span className="sl-feature-lock" aria-hidden="true">🔒</span>}
       <span className="sl-feature-icon" aria-hidden="true">{feature.icon}</span>
       <div className="sl-feature-name">{feature.name}</div>
       <div className="sl-feature-desc">{feature.desc}</div>
-      <span className="sl-feature-tag sl-feature-tag--public">🌐 공개</span>
+      <span className={`sl-feature-tag sl-feature-tag--${variant}`}>{label}</span>
     </>
   );
 
+  const commonProps = {
+    className: 'sl-feature',
+    'data-locked': locked ? 'true' : 'false',
+    onClick: handleClick,
+  };
+
   if (feature.external) {
     return (
-      <a className="sl-feature" data-locked="false" href={feature.to} target="_blank" rel="noopener noreferrer">
+      <a {...commonProps} href={feature.to} target="_blank" rel="noopener noreferrer">
+        {inner}
+      </a>
+    );
+  }
+  if (locked) {
+    return (
+      <a {...commonProps} href={feature.to}>
         {inner}
       </a>
     );
   }
   return (
-    <Link className="sl-feature" data-locked="false" to={feature.to}>
+    <Link {...commonProps} to={feature.to}>
       {inner}
     </Link>
   );
 };
 
+interface ToastProps { toast: ToastModel | null; onClose: () => void; }
+const Toast: React.FC<ToastProps> = ({ toast, onClose }) => {
+  if (!toast) return null;
+  return (
+    <div className="sl-toast" role="status" aria-live="polite">
+      <span className="sl-toast-icon" aria-hidden="true">{toast.icon}</span>
+      <span className="sl-toast-msg">{toast.message}</span>
+      <Link className="sl-toast-action" to={toast.actionTo} onClick={onClose}>
+        {toast.actionLabel} →
+      </Link>
+      <button type="button" className="sl-toast-close" onClick={onClose} aria-label="닫기">×</button>
+    </div>
+  );
+};
+
 const GatewayLanding: React.FC = () => {
+  const [toast, setToast] = useState<ToastModel | null>(null);
+
+  useEffect(() => {
+    if (!toast) return undefined;
+    const timer = setTimeout(() => setToast(null), 4500);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  const handleLocked = useCallback((accessState: AccessState) => {
+    const next = lockedToastFor(accessState);
+    if (next) setToast(next);
+  }, []);
+
+  const authState: AuthState = { isAuthenticated: false, isAdmin: false };
+
   return (
     <div className="gateway-landing-root">
       <div className="sl-container">
@@ -101,7 +201,12 @@ const GatewayLanding: React.FC = () => {
           <div className="sl-section-title">Features</div>
           <div className="sl-features">
             {FEATURES.map((feature) => (
-              <FeatureCard key={feature.name} feature={feature} />
+              <FeatureCard
+                key={feature.name}
+                feature={feature}
+                accessState={accessFor(feature.level, authState)}
+                onLocked={handleLocked}
+              />
             ))}
           </div>
         </section>
@@ -194,6 +299,8 @@ const GatewayLanding: React.FC = () => {
           </div>
         </section>
       </div>
+
+      <Toast toast={toast} onClose={() => setToast(null)} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- \`infrawatcher.unmong.com\` 자체 도메인 \`/\` 진입 시 SERVICE_LANDING_GUIDE 5섹션 표준 시작페이지 노출
- AuthContext 가 없는 서비스이므로 모든 카드는 public 처리 — 권한 게이팅 없음
- 서비스컬러: \`#06b6d4\` (cyan)

## 라우트 변경
| 이전 | 이후 |
|---|---|
| \`/\` → DashboardPage (AppLayout 안) | \`/\` → GatewayLanding (Layout 외부, 풀스크린 다크) |
| — | \`/dashboard\` → DashboardPage (AppLayout 안) |
| \`/container/:name\`, \`/group/:name\` | 동일 (AppLayout 유지) |

## Features 카드
- 실시간 대시보드 / 헬스체크 / 그룹 관리 / API Docs (외부)

## Connected Services
- AllergyInsight, EduFit, NewsLetterPlatform, StandUp, QA-Agent, LogAnalyzer

## 변경 파일
- \`frontend/src/pages/gateway-landing/GatewayLanding.tsx\` — 신규
- \`frontend/src/pages/gateway-landing/GatewayLanding.css\` — 신규 (정본 복사 + service-color)
- \`frontend/src/App.tsx\` — Routes 재구성, AppLayout 분기

## Test plan
- [ ] \`/\` 진입 시 다크 테마 5섹션 정상 노출
- [ ] 실시간 대시보드 카드 → \`/dashboard\` (AppLayout 진입, WebSocket 정상 연결)
- [ ] 그룹 관리 카드 → \`/group\` (라우트 매칭 확인)
- [ ] API Docs 카드 → 새 탭
- [ ] WebSocket connected 상태 표시 정상 (AppLayout 안에서만)

## 참고
표준: Claude-Opus-bluevlad/standards/documentation/SERVICE_LANDING_GUIDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)